### PR TITLE
Add steel sentinels to ruins pop tables

### DIFF
--- a/SteelSentinel/PopulationTables.xml
+++ b/SteelSentinel/PopulationTables.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<populations>
+
+<population Name="Tier4RuinsRobots" Load="Merge">
+	<group Name="Creatures" Style="pickone" Load="Merge">
+      <object Weight="1" Number="1" Blueprint="Sal_SteelSentinel" />  
+	</group>
+</population>
+
+<population Name="Tier5RuinsRobots" Load="Merge">
+	<group Name="Creatures" Style="pickone" Load="Merge">
+      <object Weight="5" Number="1" Blueprint="Sal_SteelSentinel" />  
+	</group>
+</population>
+
+<population Name="Tier6RuinsRobots" Load="Merge">
+	<group Name="Creatures" Style="pickone" Load="Merge">
+      <object Weight="2" Number="1" Blueprint="Sal_SteelSentinel" />  
+	</group>
+</population>
+</populations>


### PR DESCRIPTION
Steel Sentinels do not currently appear in game by default. This PR adds a few pop tables to fix that.

Since the flavortext implies they're eater tech, I added them as a robot spawn to mid-tier ruins, most prominently at Tier 5 (their level is a bit lower than Tier 5, but they have Tier 5 weapons and _very_ high strength).

I was also considering adding them to prison historic sites, but historic sites only have wall/furniture spawns, and it would probably mess something up if I put a creature in there instead.

Please note that I am not the author of this mod, but I tried to go in line with what the flavor of their creature implied, and hopefully respect their wishes.